### PR TITLE
Buildline

### DIFF
--- a/minigamesdistribution/src/assembly/bin.xml
+++ b/minigamesdistribution/src/assembly/bin.xml
@@ -18,7 +18,10 @@
                 <includeDependencies>true</includeDependencies>
                 <excludes>
                     <exclude>org.bstats:bstats-bukkit:jar</exclude>
+                    <exclude>org.bstats:bstats-base:jar</exclude>
                     <exclude>io.papermc:paperlib:jar</exclude>
+                    <exclude>org.apache.commons:commons-text:jar</exclude>
+                    <exclude>org.apache.commons:commons-lang3:jar</exclude>
                 </excludes>
                 <unpack>false</unpack>
             </binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -174,23 +174,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <executions>
-                        <execution>
-                            <id>attach-sources</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                            <phase>package</phase>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <skipSource>false</skipSource>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.1</version>
                 </plugin>


### PR DESCRIPTION
I don't know if it was safe to remove the maven plugin from the projects pom (but still having it in the project module poms).
But it's the only way of getting ready for maven 4, the only one I know at least.
Plaese some one check it and merge afterwards.